### PR TITLE
feat(week3): add top-level integration skeleton and mesh NoC stubs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,3 +87,23 @@ synth_tile:
 # Dummy sim_main.cpp for Verilator compilation
 sim_main.cpp:
 	@echo "int main(int argc, char** argv) { return 0; }" > sim_main.cpp
+
+# --- Week 3 Targets ---
+.PHONY: lint_top compile_top synth_top formal_top
+
+lint_top:
+	@echo "Linting top-level RTL..."
+	verilator --lint-only -sv rtl/neuraedge_top.v rtl/router_mesh.v --top-module neuraedge_top
+
+compile_top:
+	@echo "Compiling top-level simulation..."
+	cp -f top_main.cpp obj_dir/
+	verilator --cc -exe --build -j0 -sv rtl/neuraedge_top.v rtl/router_mesh.v top_main.cpp
+
+synth_top:
+	@echo "Synthesizing top-level..."
+	yosys -p "read_verilog -sv rtl/neuraedge_top.v rtl/router_mesh.v; synth -top neuraedge_top; stat"
+
+formal_top:
+	@echo "Parsing top-level formal stubs..."
+	for f in formal/top_*.sby; do sby --mode parse $$f || exit 1; done

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -1,0 +1,37 @@
+# Makefile for Verilator + Yosys + SymbiYosys CI flow
+
+# --- Variables ---
+VERILATOR       ?= verilator
+YOSYS           ?= yosys
+SBY             ?= sby
+
+# RTL sources for tile and NoC
+TILE_SOURCES    = $(wildcard rtl/tile/*.v) \
+                  $(wildcard rtl/noc/*.v)
+
+# --- Targets ---
+.PHONY: lint_tile compile_tile synth_tile formal_compile clean
+
+lint_tile:
+	@echo "Linting tile and NoC RTL files..."
+	@$(VERILATOR) --lint-only -sv $(TILE_SOURCES) --top-module neuraedge_tile
+
+compile_tile:
+	@echo "Compiling tile RTL for simulation..."
+	cp -f tile_main.cpp obj_dir/
+	@$(VERILATOR) --cc -exe --build -j0 -sv $(TILE_SOURCES) --top-module neuraedge_tile tile_main.cpp
+
+synth_tile:
+	@echo "Running synthesis for tile..."
+	@$(YOSYS) -p "read_verilog -sv $(TILE_SOURCES); synth -top neuraedge_tile; stat"
+
+formal_compile:
+	@echo "Checking formal property files..."
+	@for f in formal/*.sby; do \
+	  $(SBY) --mode parse $$f || exit 1; \
+	done
+
+clean:
+	@echo "Cleaning up..."
+	@rm -rf obj_dir/
+	@rm -f *.o *.vcd *.log

--- a/Makefile.minimal
+++ b/Makefile.minimal
@@ -1,0 +1,2 @@
+test:
+	@echo "Test works"

--- a/Makefile.test1
+++ b/Makefile.test1
@@ -1,0 +1,2 @@
+obj_dir/main.cpp:
+	echo "Test works"

--- a/formal/top_router.sby
+++ b/formal/top_router.sby
@@ -1,0 +1,13 @@
+[options]
+mode bmc
+
+[engines]
+smtbmc
+
+[script]
+read_verilog -sv ../rtl/router_mesh.v ../formal/top_router_props.sv
+prep -top router_mesh
+
+[files]
+../rtl/router_mesh.v
+../formal/top_router_props.sv

--- a/formal/top_router_props.sv
+++ b/formal/top_router_props.sv
@@ -1,0 +1,10 @@
+// Properties for router_mesh
+module top_router_props(input clk, input rst_n, input [63:0] flit_in, output [63:0] flit_out);
+    // Example property: assert that data is not lost
+    // This is a stub and needs to be implemented
+    property data_not_lost;
+        @(posedge clk) (flit_in |-> ##[1:10] flit_out == flit_in);
+    endproperty
+    
+    assert property(data_not_lost);
+endmodule

--- a/rtl/router_mesh.v
+++ b/rtl/router_mesh.v
@@ -1,0 +1,23 @@
+// File: rtl/router_mesh.v
+// 2D mesh network connecting TILE_ROWS×TILE_COLS endpoints
+
+module router_mesh #(
+    parameter ROWS    = 4,
+    parameter COLS    = 4,
+    parameter FLIT_W  = 64
+)(
+    input  logic                   clk,
+    input  logic                   rst_n,
+    // External I/O
+    input  logic [FLIT_W-1:0]      ext_flit_in,
+    input  logic                   ext_valid_in,
+    output logic                   ext_ready_out,
+    output logic [FLIT_W-1:0]      ext_flit_out,
+    output logic                   ext_valid_out,
+    input  logic                   ext_ready_in
+    // Internally: flit_in[TILES], flit_out[TILES], etc.
+);
+
+    // TODO: implement mesh router grid, connect to tile ports
+
+endmodule

--- a/rtl/top/neuraedge_top.v
+++ b/rtl/top/neuraedge_top.v
@@ -1,0 +1,61 @@
+// File: rtl/top/neuraedge_top.v
+// Top-level NPU: NxM tile grid with 2D mesh NoC
+
+`include "neuraedge_tile.v"
+`include "router_mesh.v"
+
+module neuraedge_top #(
+    parameter TILE_ROWS       = 4,
+    parameter TILE_COLS       = 4,
+    parameter NOC_FLIT_WIDTH  = 64
+)(
+    input  logic                        clk,
+    input  logic                        rst_n,
+    // Global I/O to memory/host
+    input  logic [NOC_FLIT_WIDTH-1:0]   ext_flit_in,
+    input  logic                        ext_valid_in,
+    output logic                        ext_ready_out,
+    output logic [NOC_FLIT_WIDTH-1:0]   ext_flit_out,
+    output logic                        ext_valid_out,
+    input  logic                        ext_ready_in
+);
+
+    // 2D array of tiles
+    genvar r, c;
+    generate
+        for (r = 0; r < TILE_ROWS; r = r + 1) begin : ROW
+            for (c = 0; c < TILE_COLS; c = c + 1) begin : COL
+                neuraedge_tile tile_inst (
+                    .clk         (clk),
+                    .rst_n       (rst_n),
+                    // TODO: connect flit_in/flit_out to mesh router ports
+                    .flit_in     (/* N,E,S,W,Local from mesh */),
+                    .valid_in    (/* ... */),
+                    .ready_out   (/* ... */),
+                    .flit_out    (/* ... */),
+                    .valid_out   (/* ... */),
+                    .ready_in    (/* ... */)
+                );
+            end
+        end
+    endgenerate
+
+    // Mesh NoC router fabric
+    router_mesh #(
+        .ROWS    (TILE_ROWS),
+        .COLS    (TILE_COLS),
+        .FLIT_W  (NOC_FLIT_WIDTH)
+    ) mesh_inst (
+        .clk            (clk),
+        .rst_n          (rst_n),
+        // Link the ext_* ports to the boundary routers
+        .ext_flit_in    (ext_flit_in),
+        .ext_valid_in   (ext_valid_in),
+        .ext_ready_out  (ext_ready_out),
+        .ext_flit_out   (ext_flit_out),
+        .ext_valid_out  (ext_valid_out),
+        .ext_ready_in   (ext_ready_in)
+        // TODO: internal tile port arrays automatically connected
+    );
+
+endmodule

--- a/top_main.cpp
+++ b/top_main.cpp
@@ -1,0 +1,48 @@
+// File: top_main.cpp
+#include "Vneuraedge_top.h"
+#include "verilated.h"
+#include "verilated_vcd_c.h"
+
+int main(int argc, char** argv) {
+    Verilated::commandArgs(argc, argv);
+    Vneuraedge_top* dut = new Vneuraedge_top;
+    Verilated::traceEverOn(true);
+    VerilatedVcdC* tfp = new VerilatedVcdC;
+    dut->trace(tfp, 99);
+    tfp->open("top_sim.vcd");
+
+    // Initialize
+    dut->clk = 0;
+    dut->rst_n = 0;
+    dut->ext_valid_in = 0;
+    dut->ext_flit_in = 0;
+
+    const int SIM_CYCLES = 1000;
+    for (int cycle = 0; cycle < SIM_CYCLES; cycle++) {
+        dut->clk = !dut->clk;
+        if (cycle == 5 && dut->clk) dut->rst_n = 1;
+
+        // Example external input stimulus
+        if (cycle > 10 && cycle < 20 && dut->clk) {
+            dut->ext_valid_in = 1;
+            dut->ext_flit_in  = 0xCAFEBABE;
+        } else {
+            dut->ext_valid_in = 0;
+        }
+
+        dut->eval();
+        tfp->dump(2*cycle + (dut->clk ? 1 : 0));
+        
+        if (dut->clk && (cycle % 200 == 0)) {
+            printf("Cycle %d ext_valid=%d ext_ready=%d ext_flit=0x%016llx\n",
+                   cycle, dut->ext_valid_in, dut->ext_ready_out,
+                   (unsigned long long)dut->ext_flit_out);
+        }
+    }
+
+    dut->final();
+    tfp->close();
+    delete tfp;
+    delete dut;
+    return 0;
+}


### PR DESCRIPTION
## Week 3: Top-Level Integration & System Assembly

This PR lays the groundwork for full NPU integration:

Deliverables Added
- `rtl/top/neuraedge_top.v`: top-level module instantiating a TILE_ROWS×TILE_COLS grid of neuraedge_tile and mesh router  
- `rtl/router_mesh.v`: 2D mesh NoC router skeleton  
- `top_main.cpp`: system-level Verilator testbench with clock/reset and external-interface stimulus  
- `formal/top_router.sby` & `formal/top_router_props.sv`: SymbiYosys configs and placeholder properties for mesh connectivity  
- **Makefile**: new targets `lint_top`, `compile_top`, `synth_top`, `formal_top`

Gate Criteria  
- [ ] `make lint_top` passes without warnings  
- [ ] `make compile_top` builds successfully  
- [ ] `make synth_top` synthesizes cleanly  
- [ ] `make formal_top` parses all `.sby` files

Upon merge, we complete Week 3 scaffolding and can begin wiring inter-tile links and functional RTL.
